### PR TITLE
Add V8Js CI test with Docker image

### DIFF
--- a/.github/docker/Dockerfile.v8js
+++ b/.github/docker/Dockerfile.v8js
@@ -1,0 +1,81 @@
+# PHP 8.5 + V8Js Docker Image
+# Based on https://github.com/phpv8/v8js/blob/php8/README.Linux.md
+
+ARG PHP_VERSION=8.5
+ARG V8_VERSION=12.4.254.21
+
+FROM php:${PHP_VERSION}-cli AS builder
+
+ARG V8_VERSION
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    python3 \
+    python3-pip \
+    pkg-config \
+    libglib2.0-dev \
+    build-essential \
+    ninja-build \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install depot_tools
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools
+ENV PATH="/opt/depot_tools:${PATH}"
+
+# Fetch and build V8
+WORKDIR /tmp/v8
+RUN fetch v8 \
+    && cd v8 \
+    && git checkout ${V8_VERSION} \
+    && gclient sync -D
+
+WORKDIR /tmp/v8/v8
+RUN tools/dev/v8gen.py -vv x64.release -- \
+    is_component_build=true \
+    use_custom_libcxx=false \
+    v8_enable_sandbox=false
+
+RUN ninja -C out.gn/x64.release
+
+# Install V8 to /opt/v8
+RUN mkdir -p /opt/v8/{lib,include} \
+    && cp out.gn/x64.release/lib*.so out.gn/x64.release/*_blob.bin /opt/v8/lib/ \
+    && cp -R include/* /opt/v8/include/
+
+# Build v8js extension
+WORKDIR /tmp
+RUN git clone --depth=1 --branch php8 https://github.com/phpv8/v8js.git
+
+WORKDIR /tmp/v8js
+RUN phpize \
+    && ./configure --with-v8js=/opt/v8 LDFLAGS="-lstdc++" CPPFLAGS="-DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX=0" \
+    && make -j$(nproc) \
+    && make install
+
+# Final image
+FROM php:${PHP_VERSION}-cli
+
+# Copy V8 libraries
+COPY --from=builder /opt/v8 /opt/v8
+
+# Copy v8js extension
+COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-*/v8js.so /usr/local/lib/php/extensions/
+
+# Configure extension
+RUN echo "extension=v8js.so" > /usr/local/etc/php/conf.d/v8js.ini
+
+# Set library path
+ENV LD_LIBRARY_PATH="/opt/v8/lib:${LD_LIBRARY_PATH}"
+
+# Verify installation
+RUN php -m | grep v8js
+
+# Install common tools
+RUN apt-get update && apt-get install -y \
+    git \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     name: PHPUnit with V8Js (Docker)
     runs-on: ubuntu-latest
     container:
-      image: interposition/8.4.14-fpm-trixie-v8js:latest
+      image: interposition/8.4.14-fpm-trixie-v8js:v1
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,44 @@ jobs:
       - name: Run PHP_CodeSniffer
         run: ./vendor/bin/phpcs
 
+  v8js-test:
+    name: PHPUnit with V8Js (Alpine 3.16)
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.16
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          apk add --no-cache \
+            php81 php81-dev php81-phar php81-mbstring php81-openssl php81-curl php81-dom php81-xml php81-xmlwriter php81-tokenizer php81-simplexml \
+            composer npm git \
+            nodejs-dev \
+            build-base python3
+
+      - name: Build V8Js extension
+        run: |
+          git clone --depth=1 --branch php8 https://github.com/phpv8/v8js.git /tmp/v8js
+          cd /tmp/v8js
+          phpize81
+          ./configure --with-php-config=/usr/bin/php-config81 --with-v8js=/usr
+          make -j$(nproc)
+          make install
+          echo "extension=v8js.so" > /etc/php81/conf.d/v8js.ini
+
+      - name: Verify V8Js
+        run: php81 -m | grep v8js
+
+      - name: Build Redux example
+        run: |
+          cd docs/example/redux
+          npm install
+          npm run build
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress
+
+      - name: Run PHPUnit
+        run: php81 vendor/bin/phpunit
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,14 @@ jobs:
             nodejs-dev \
             build-base python3
 
+      - name: Debug V8 location
+        run: |
+          echo "=== Searching for V8 headers ==="
+          find /usr -name "v8.h" 2>/dev/null || echo "v8.h not found"
+          find /usr -name "libv8*" 2>/dev/null || echo "libv8 not found"
+          echo "=== Package contents ==="
+          apk info -L nodejs-dev | head -50
+
       - name: Build V8Js extension
         run: |
           git clone --depth=1 --branch php8 https://github.com/phpv8/v8js.git /tmp/v8js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,44 +75,26 @@ jobs:
         run: ./vendor/bin/phpcs
 
   v8js-test:
-    name: PHPUnit with V8Js (Ubuntu)
-    runs-on: ubuntu-22.04
+    name: PHPUnit with V8Js (Docker)
+    runs-on: ubuntu-latest
+    container:
+      image: interposition/8.4.14-fpm-trixie-v8js:latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
-          tools: composer:v2
-
-      - name: Install V8 and build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common
-          sudo add-apt-repository -y ppa:phoerious/libv8
-          sudo apt-get update
-          sudo apt-get install -y libv8-dev php-dev
-
-      - name: Debug V8 location
-        run: |
-          echo "=== Searching for V8 ==="
-          find /usr -name "v8.h" 2>/dev/null | head -5
-          find /usr -name "libv8*" 2>/dev/null | head -10
-          pkg-config --cflags --libs v8 2>/dev/null || echo "v8 pkg-config not found"
-
-      - name: Build V8Js extension
-        run: |
-          git clone --depth=1 --branch php8 https://github.com/phpv8/v8js.git /tmp/v8js
-          cd /tmp/v8js
-          phpize
-          ./configure
-          make -j$(nproc)
-          sudo make install
-          echo "extension=v8js.so" | sudo tee /etc/php/8.2/cli/conf.d/v8js.ini
-
       - name: Verify V8Js
         run: php -m | grep v8js
+
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y npm unzip git
+
+      - name: Install Composer
+        run: |
+          php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+          php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+          php -r "unlink('composer-setup.php');"
 
       - name: Build Redux example
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,41 +75,44 @@ jobs:
         run: ./vendor/bin/phpcs
 
   v8js-test:
-    name: PHPUnit with V8Js (Alpine 3.16)
-    runs-on: ubuntu-latest
-    container:
-      image: alpine:3.16
+    name: PHPUnit with V8Js (Ubuntu)
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer:v2
+
+      - name: Install V8 and build dependencies
         run: |
-          apk add --no-cache \
-            php81 php81-dev php81-phar php81-mbstring php81-openssl php81-curl php81-dom php81-xml php81-xmlwriter php81-tokenizer php81-simplexml \
-            composer npm git \
-            nodejs-dev \
-            build-base python3
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:phoerious/libv8
+          sudo apt-get update
+          sudo apt-get install -y libv8-dev php-dev
 
       - name: Debug V8 location
         run: |
-          echo "=== Searching for V8 headers ==="
-          find /usr -name "v8.h" 2>/dev/null || echo "v8.h not found"
-          find /usr -name "libv8*" 2>/dev/null || echo "libv8 not found"
-          echo "=== Package contents ==="
-          apk info -L nodejs-dev | head -50
+          echo "=== Searching for V8 ==="
+          find /usr -name "v8.h" 2>/dev/null | head -5
+          find /usr -name "libv8*" 2>/dev/null | head -10
+          pkg-config --cflags --libs v8 2>/dev/null || echo "v8 pkg-config not found"
 
       - name: Build V8Js extension
         run: |
           git clone --depth=1 --branch php8 https://github.com/phpv8/v8js.git /tmp/v8js
           cd /tmp/v8js
-          phpize81
-          ./configure --with-php-config=/usr/bin/php-config81 --with-v8js=/usr/include/node
+          phpize
+          ./configure
           make -j$(nproc)
-          make install
-          echo "extension=v8js.so" > /etc/php81/conf.d/v8js.ini
+          sudo make install
+          echo "extension=v8js.so" | sudo tee /etc/php/8.2/cli/conf.d/v8js.ini
 
       - name: Verify V8Js
-        run: php81 -m | grep v8js
+        run: php -m | grep v8js
 
       - name: Build Redux example
         run: |
@@ -121,5 +124,5 @@ jobs:
         run: composer install --no-progress
 
       - name: Run PHPUnit
-        run: php81 vendor/bin/phpunit
+        run: ./vendor/bin/phpunit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           git clone --depth=1 --branch php8 https://github.com/phpv8/v8js.git /tmp/v8js
           cd /tmp/v8js
           phpize81
-          ./configure --with-php-config=/usr/bin/php-config81 --with-v8js=/usr
+          ./configure --with-php-config=/usr/bin/php-config81 --with-v8js=/usr/include/node
           make -j$(nproc)
           make install
           echo "extension=v8js.so" > /etc/php81/conf.d/v8js.ini

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,82 @@
+name: Build V8Js Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      php_version:
+        description: 'PHP Version'
+        required: true
+        default: '8.5'
+        type: choice
+        options:
+          - '8.2'
+          - '8.3'
+          - '8.4'
+          - '8.5'
+      v8_version:
+        description: 'V8 Version'
+        required: true
+        default: '12.4.254.21'
+  schedule:
+    # Monthly build on the 1st at 00:00 UTC
+    - cron: '0 0 1 * *'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/php-v8js
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set versions
+        id: versions
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "php_version=${{ inputs.php_version }}" >> $GITHUB_OUTPUT
+            echo "v8_version=${{ inputs.v8_version }}" >> $GITHUB_OUTPUT
+          else
+            echo "php_version=8.5" >> $GITHUB_OUTPUT
+            echo "v8_version=12.4.254.21" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.versions.outputs.php_version }}
+            type=raw,value=${{ steps.versions.outputs.php_version }}-v8-${{ steps.versions.outputs.v8_version }}
+            type=raw,value=latest,enable=${{ steps.versions.outputs.php_version == '8.5' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/Dockerfile.v8js
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PHP_VERSION=${{ steps.versions.outputs.php_version }}
+            V8_VERSION=${{ steps.versions.outputs.v8_version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     ],
     "require": {
         "php": ">=8.2",
-        "nacmartin/phpexecjs": "^3.1",
-        "psr/simple-cache": "^3.0"
+        "psr/simple-cache": "^3.0",
+        "symfony/process": "^6.0 || ^7.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8",

--- a/src/Baracoa.php
+++ b/src/Baracoa.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Koriym\Baracoa;
 
 use Koriym\Baracoa\Exception\JsFileNotExistsException;
-use Nacmartin\PhpExecJs\PhpExecJs;
+use Koriym\Baracoa\PhpExecJs\PhpExecJs;
 use Override;
 use V8Js;
 use V8JsScriptException;

--- a/src/PhpExecJs/ExternalRuntime.php
+++ b/src/PhpExecJs/ExternalRuntime.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Baracoa\PhpExecJs;
+
+use Override;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+use function array_filter;
+use function assert;
+use function exec;
+use function explode;
+use function file_exists;
+use function file_put_contents;
+use function getenv;
+use function is_dir;
+use function is_executable;
+use function is_string;
+use function is_writable;
+use function json_decode;
+use function json_encode;
+use function mkdir;
+use function register_shutdown_function;
+use function rtrim;
+use function sprintf;
+use function str_starts_with;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+use const DIRECTORY_SEPARATOR;
+use const PATH_SEPARATOR;
+use const PHP_OS;
+
+/**
+ * External JavaScript runtime using Node.js
+ */
+final class ExternalRuntime implements RuntimeInterface
+{
+    /** @var list<string> */
+    private array $temporaryFiles = [];
+    private string|null $context = null;
+    private string|null $binaryPath;
+
+    /**
+     * @param list<string>         $binary Binary names to search for
+     * @param array<string, mixed> $env    Environment variables
+     */
+    public function __construct(
+        private readonly string $name = 'Node.js (V8)',
+        private readonly array $binary = ['node', 'nodejs'],
+        private readonly array|null $env = null,
+        private int|false $timeout = false,
+    ) {
+        $this->binaryPath = $this->findBinaryPath();
+        register_shutdown_function([$this, 'removeTemporaryFiles']);
+    }
+
+    public function __destruct()
+    {
+        $this->removeTemporaryFiles();
+    }
+
+    #[Override]
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    #[Override]
+    public function isAvailable(): bool
+    {
+        return $this->binaryPath !== null;
+    }
+
+    #[Override]
+    public function evalJs(string $code): mixed
+    {
+        assert($this->binaryPath !== null, 'Runtime must be available');
+
+        $encodedCode = json_encode($code);
+        assert($encodedCode !== false);
+        $code = 'return eval(' . $encodedCode . ');';
+        if ($this->context !== null) {
+            $code = $this->context . "\n" . $code;
+        }
+
+        $code = $this->embedInRuntime($code);
+        $sourceFile = $this->createTemporaryFile($code, 'js');
+
+        $command = $this->binaryPath;
+        if (str_starts_with(PHP_OS, 'WIN')) {
+            $command = '"' . $this->binaryPath . '"';
+        }
+
+        $command .= ' ' . $sourceFile;
+
+        [$status, $stdout, $stderr] = $this->executeCommand($command);
+        $this->checkProcessStatus($status, $stdout, $stderr, $command);
+
+        /** @var array{0: string, 1?: mixed} $decoded */
+        $decoded = json_decode($stdout, true);
+        $this->checkEvalStatus($decoded[0], $decoded[1] ?? null);
+
+        return $decoded[1] ?? null;
+    }
+
+    public function createContext(string $code): void
+    {
+        $this->context = $code;
+    }
+
+    public function setTimeout(int $timeout): void
+    {
+        $this->timeout = $timeout;
+    }
+
+    public function removeTemporaryFiles(): void
+    {
+        foreach ($this->temporaryFiles as $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+
+        $this->temporaryFiles = [];
+    }
+
+    private function embedInRuntime(string $code): string
+    {
+        return <<<JS
+(function(program, execJS) { execJS(program) })(function(global, module, exports, require, console, setTimeout, setInterval, clearTimeout, clearInterval, setImmediate, clearImmediate) { $code;
+}, function(program) {
+  var output, print = function(string) {
+    process.stdout.write('' + string);
+  };
+  try {
+    result = program();
+    if (typeof result == 'undefined' && result !== null) {
+      print('["ok"]');
+    } else {
+      try {
+        print(JSON.stringify(['ok', result]));
+      } catch (err) {
+        print(JSON.stringify(['err', '' + err, err.stack]));
+      }
+    }
+  } catch (err) {
+    print(JSON.stringify(['err', '' + err, err.stack]));
+  }
+});
+JS;
+    }
+
+    private function createTemporaryFile(string $content, string $extension): string
+    {
+        $dir = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR);
+        if (! is_dir($dir)) {
+            if (@mkdir($dir, 0777, true) === false && ! is_dir($dir)) {
+                throw new RuntimeException(sprintf("Unable to create directory: %s\n", $dir));
+            }
+        } elseif (! is_writable($dir)) {
+            throw new RuntimeException(sprintf("Unable to write in directory: %s\n", $dir));
+        }
+
+        $filename = $dir . DIRECTORY_SEPARATOR . uniqid('koriym_baracoa_phpexecjs', true) . '.' . $extension;
+        file_put_contents($filename, $content);
+        $this->temporaryFiles[] = $filename;
+
+        return $filename;
+    }
+
+    private function findBinaryPath(): string|null
+    {
+        $pathStr = getenv('PATH');
+        if ($pathStr === false) {
+            $pathStr = '';
+        }
+
+        $paths = array_filter(explode(PATH_SEPARATOR, $pathStr));
+        foreach ($paths as $path) {
+            foreach ($this->binary as $binary) {
+                $binaryPath = $path . DIRECTORY_SEPARATOR . $binary;
+                if (is_executable($binaryPath)) {
+                    return $binaryPath;
+                }
+
+                if (str_starts_with(PHP_OS, 'WIN')) {
+                    $binaryPath .= '.exe';
+                    if (is_executable($binaryPath)) {
+                        return $binaryPath;
+                    }
+                }
+            }
+        }
+
+        foreach ($this->binary as $binary) {
+            $whichBinaryPath = exec('which ' . $binary);
+            if ($whichBinaryPath !== false && $whichBinaryPath !== '') {
+                return $whichBinaryPath;
+            }
+        }
+
+        return null;
+    }
+
+    private function checkProcessStatus(int $status, string $stdout, string $stderr, string $command): void
+    {
+        if ($status !== 0 && $stderr !== '') {
+            throw new RuntimeException(sprintf(
+                'The exit status code \'%s\' says something went wrong:' . "\n"
+                . 'stderr: "%s"' . "\n"
+                . 'stdout: "%s"' . "\n"
+                . 'command: %s.',
+                $status,
+                $stderr,
+                $stdout,
+                $command,
+            ));
+        }
+    }
+
+    private function checkEvalStatus(string $statusEval, mixed $result): void
+    {
+        if ($statusEval === 'ok') {
+            return;
+        }
+
+        $encoded = json_encode($result);
+        $resultStr = $encoded !== false ? $encoded : 'unknown';
+
+        throw new RuntimeException(sprintf(
+            'Something went wrong evaluating JS code:' . "\n"
+            . 'result: "%s"',
+            $resultStr,
+        ));
+    }
+
+    /** @return array{int, string, string} */
+    private function executeCommand(string $command): array
+    {
+        $process = Process::fromShellCommandline($command, null, $this->env);
+
+        if ($this->timeout !== false) {
+            $process->setTimeout($this->timeout);
+        }
+
+        $process->run();
+
+        return [
+            $process->getExitCode() ?? 1,
+            $process->getOutput(),
+            $process->getErrorOutput(),
+        ];
+    }
+}

--- a/src/PhpExecJs/ExternalRuntime.php
+++ b/src/PhpExecJs/ExternalRuntime.php
@@ -17,7 +17,6 @@ use function file_put_contents;
 use function getenv;
 use function is_dir;
 use function is_executable;
-use function is_string;
 use function is_writable;
 use function json_decode;
 use function json_encode;

--- a/src/PhpExecJs/PhpExecJs.php
+++ b/src/PhpExecJs/PhpExecJs.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Baracoa\PhpExecJs;
+
+use RuntimeException;
+
+/**
+ * PHP JavaScript execution using external runtime (Node.js)
+ */
+final class PhpExecJs
+{
+    private readonly ExternalRuntime $runtime;
+
+    public function __construct()
+    {
+        $this->runtime = new ExternalRuntime();
+        if (! $this->runtime->isAvailable()) {
+            throw new RuntimeException('PhpExecJs: Node.js runtime not found. Please install Node.js.');
+        }
+    }
+
+    /**
+     * Returns the name of the current runtime.
+     */
+    public function getRuntimeName(): string
+    {
+        return $this->runtime->getName();
+    }
+
+    /**
+     * Evaluates JS code and returns the output.
+     */
+    public function evalJs(string $code): mixed
+    {
+        return $this->runtime->evalJs($code);
+    }
+}

--- a/src/PhpExecJs/RuntimeInterface.php
+++ b/src/PhpExecJs/RuntimeInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Baracoa\PhpExecJs;
+
+interface RuntimeInterface
+{
+    /**
+     * Evaluates JS code and returns the output.
+     */
+    public function evalJs(string $code): mixed;
+
+    /**
+     * Checks if the runtime is available.
+     */
+    public function isAvailable(): bool;
+
+    /**
+     * Returns the name of the runtime.
+     */
+    public function getName(): string;
+}


### PR DESCRIPTION
## Summary
Add V8Js CI test using Docker image `interposition/8.4.14-fpm-trixie-v8js:v1` which has PHP 8.4 and V8Js pre-installed.

## Changes
- Added `v8js-test` job using Docker container
- Tests run with actual V8Js extension instead of PhpExecJs fallback

## Test plan
- [x] V8Js Docker image pulls successfully
- [x] PHPUnit tests pass with V8Js extension

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for executing JavaScript via an external Node.js runtime from the PHP library, with runtime detection, persistent contexts, and safe cleanup.
* **Chores**
  * Add CI job to run tests inside a container with V8/Node.js support to validate build and PHPUnit tests.
* **Dependencies**
  * Adjusted PHP dependencies to support the new external runtime integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->